### PR TITLE
エラーメッセージの日本語化に伴うテストコード修正作業

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -29,3 +29,5 @@ ja:
         building: 建物名
         phone_number: 電話番号
         token: カード情報
+        user_id: ユーザー
+        item_id: 商品

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -16,85 +16,85 @@ RSpec.describe Item, type: :model do
       it 'imageがなければ出品できない' do
         @item.image = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Image can't be blank")
+        expect(@item.errors.full_messages).to include("出品画像を入力してください")
       end
 
       it 'nameがなければ出品できない' do
         @item.name = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Name can't be blank")
+        expect(@item.errors.full_messages).to include("商品名を入力してください")
       end
 
       it 'explainがなければ出品できない' do
         @item.explain = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Explain can't be blank")
+        expect(@item.errors.full_messages).to include("商品の説明を入力してください")
       end
 
       it 'priceがなければ出品できない' do
         @item.price = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price can't be blank")
+        expect(@item.errors.full_messages).to include("販売価格を入力してください")
       end
 
       it 'priceは半角数字でなければ出品できない' do
         @item.price = '１０００'
         @item.valid?
-        expect(@item.errors.full_messages).to include('Price Out of setting range')
+        expect(@item.errors.full_messages).to include('販売価格は300円から10,000,000円未満です')
       end
 
       it 'priceが半角英数字混合では出品できない' do
         @item.price = '1000yen'
         @item.valid?
-        expect(@item.errors.full_messages).to include('Price Out of setting range')
+        expect(@item.errors.full_messages).to include('販売価格は300円から10,000,000円未満です')
       end
 
       it 'priceが半角英字のみでは出品できない' do
         @item.price = 'price'
         @item.valid?
-        expect(@item.errors.full_messages).to include('Price Out of setting range')
+        expect(@item.errors.full_messages).to include('販売価格は300円から10,000,000円未満です')
       end
 
       it 'priceは300未満だと出品できない' do
         @item.price = 100
         @item.valid?
-        expect(@item.errors.full_messages).to include('Price Out of setting range')
+        expect(@item.errors.full_messages).to include('販売価格は300円から10,000,000円未満です')
       end
 
       it 'priceは10000000以上だと出品できない' do
         @item.price = 10_000_000
         @item.valid?
-        expect(@item.errors.full_messages).to include('Price Out of setting range')
+        expect(@item.errors.full_messages).to include('販売価格は300円から10,000,000円未満です')
       end
 
       it 'category_idは0以外でなければ出品できない' do
         @item.category_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include('Category Select')
+        expect(@item.errors.full_messages).to include('カテゴリーを選択してください')
       end
 
       it 'item_status_idは0以外でなければ出品できない' do
         @item.item_status_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include('Item status Select')
+        expect(@item.errors.full_messages).to include('商品の状態を選択してください')
       end
 
       it 'shipping_fee_idは0以外でなければ出品できない' do
         @item.shipping_fee_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include('Shipping fee Select')
+        expect(@item.errors.full_messages).to include('配送料の負担を選択してください')
       end
 
       it 'prefecture_idは0以外でなければ出品できない' do
         @item.prefecture_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include('Prefecture Select')
+        expect(@item.errors.full_messages).to include('発送元の地域を選択してください')
       end
 
       it 'delivery_idは0以外でなければ出品できない' do
         @item.delivery_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include('Delivery Select')
+        expect(@item.errors.full_messages).to include('発送までの日数を選択してください')
       end
     end
   end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -16,25 +16,25 @@ RSpec.describe Item, type: :model do
       it 'imageがなければ出品できない' do
         @item.image = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("出品画像を入力してください")
+        expect(@item.errors.full_messages).to include('出品画像を入力してください')
       end
 
       it 'nameがなければ出品できない' do
         @item.name = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("商品名を入力してください")
+        expect(@item.errors.full_messages).to include('商品名を入力してください')
       end
 
       it 'explainがなければ出品できない' do
         @item.explain = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("商品の説明を入力してください")
+        expect(@item.errors.full_messages).to include('商品の説明を入力してください')
       end
 
       it 'priceがなければ出品できない' do
         @item.price = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("販売価格を入力してください")
+        expect(@item.errors.full_messages).to include('販売価格を入力してください')
       end
 
       it 'priceは半角数字でなければ出品できない' do

--- a/spec/models/order_shipping_spec.rb
+++ b/spec/models/order_shipping_spec.rb
@@ -31,67 +31,67 @@ RSpec.describe OrderShipping, type: :model do
       it 'postal_codeがなければ購入できない' do
         @order_shipping.postal_code = nil
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include("Postal code can't be blank")
+        expect(@order_shipping.errors.full_messages).to include("郵便番号を入力してください")
       end
 
       it 'postal_codeはハイフンが必要' do
         @order_shipping.postal_code = '1234567'
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include('Postal code is invalid')
+        expect(@order_shipping.errors.full_messages).to include('郵便番号は不正な値です')
       end
 
       it 'prefecture_idを選択しなければ購入できない' do
         @order_shipping.prefecture_id = 0
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include('Prefecture Select')
+        expect(@order_shipping.errors.full_messages).to include('都道府県を選択してください')
       end
 
       it 'cityがなければ購入できない' do
         @order_shipping.city = nil
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include("City can't be blank")
+        expect(@order_shipping.errors.full_messages).to include("市区町村を入力してください")
       end
 
       it 'addressがなければ購入できない' do
         @order_shipping.address = nil
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include("Address can't be blank")
+        expect(@order_shipping.errors.full_messages).to include("番地を入力してください")
       end
 
       it 'phone_numberがなければ購入できない' do
         @order_shipping.phone_number = nil
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include("Phone number can't be blank")
+        expect(@order_shipping.errors.full_messages).to include("電話番号を入力してください")
       end
 
       it 'phone_numberが12桁以上では購入できない' do
         @order_shipping.phone_number = '012345678901'
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include('Phone number is invalid')
+        expect(@order_shipping.errors.full_messages).to include('電話番号は不正な値です')
       end
 
       it 'phone_numberが英数混合では登録できない' do
         @order_shipping.phone_number = 'o9012345678'
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include('Phone number is invalid')
+        expect(@order_shipping.errors.full_messages).to include('電話番号は不正な値です')
       end
 
       it 'tokenがなければ購入できない' do
         @order_shipping.token = nil
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include("Token can't be blank")
+        expect(@order_shipping.errors.full_messages).to include("カード情報を入力してください")
       end
 
       it 'user_idがなければ購入できない' do
         @order_shipping.user_id = nil
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include("User can't be blank")
+        expect(@order_shipping.errors.full_messages).to include("ユーザーを入力してください")
       end
 
       it 'item_idがなければ購入できない' do
         @order_shipping.item_id = nil
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include("Item can't be blank")
+        expect(@order_shipping.errors.full_messages).to include("商品を入力してください")
       end
     end
   end

--- a/spec/models/order_shipping_spec.rb
+++ b/spec/models/order_shipping_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe OrderShipping, type: :model do
       it 'postal_codeがなければ購入できない' do
         @order_shipping.postal_code = nil
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include("郵便番号を入力してください")
+        expect(@order_shipping.errors.full_messages).to include('郵便番号を入力してください')
       end
 
       it 'postal_codeはハイフンが必要' do
@@ -49,19 +49,19 @@ RSpec.describe OrderShipping, type: :model do
       it 'cityがなければ購入できない' do
         @order_shipping.city = nil
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include("市区町村を入力してください")
+        expect(@order_shipping.errors.full_messages).to include('市区町村を入力してください')
       end
 
       it 'addressがなければ購入できない' do
         @order_shipping.address = nil
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include("番地を入力してください")
+        expect(@order_shipping.errors.full_messages).to include('番地を入力してください')
       end
 
       it 'phone_numberがなければ購入できない' do
         @order_shipping.phone_number = nil
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include("電話番号を入力してください")
+        expect(@order_shipping.errors.full_messages).to include('電話番号を入力してください')
       end
 
       it 'phone_numberが12桁以上では購入できない' do
@@ -79,19 +79,19 @@ RSpec.describe OrderShipping, type: :model do
       it 'tokenがなければ購入できない' do
         @order_shipping.token = nil
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include("カード情報を入力してください")
+        expect(@order_shipping.errors.full_messages).to include('カード情報を入力してください')
       end
 
       it 'user_idがなければ購入できない' do
         @order_shipping.user_id = nil
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include("ユーザーを入力してください")
+        expect(@order_shipping.errors.full_messages).to include('ユーザーを入力してください')
       end
 
       it 'item_idがなければ購入できない' do
         @order_shipping.item_id = nil
         @order_shipping.valid?
-        expect(@order_shipping.errors.full_messages).to include("商品を入力してください")
+        expect(@order_shipping.errors.full_messages).to include('商品を入力してください')
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,13 +16,13 @@ RSpec.describe User, type: :model do
       it 'nicknameが空では登録できない' do
         @user.nickname = nil
         @user.valid?
-        expect(@user.errors.full_messages).to include("Nickname can't be blank")
+        expect(@user.errors.full_messages).to include("ニックネームを入力してください")
       end
 
       it 'emailが空では登録できない' do
         @user.email = nil
         @user.valid?
-        expect(@user.errors.full_messages).to include("Email can't be blank")
+        expect(@user.errors.full_messages).to include("Eメールを入力してください")
       end
 
       it '重複したemailは登録できない' do
@@ -30,19 +30,19 @@ RSpec.describe User, type: :model do
         @other_user = FactoryBot.build(:user)
         @other_user.email = @user.email
         @other_user.valid?
-        expect(@other_user.errors.full_messages).to include('Email has already been taken')
+        expect(@other_user.errors.full_messages).to include('Eメールはすでに存在します')
       end
 
       it 'emailに@が含まれていないと登録できない' do
         @user.email = 'test.com'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Email is invalid')
+        expect(@user.errors.full_messages).to include('Eメールは不正な値です')
       end
 
       it 'passwordが空では登録できない' do
         @user.password = nil
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password can't be blank")
+        expect(@user.errors.full_messages).to include("パスワードを入力してください")
       end
 
       it 'passwordは6文字以上でなければ登録できない' do
@@ -50,14 +50,14 @@ RSpec.describe User, type: :model do
         @user.password = password
         @user.password_confirmation = password
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password is too short (minimum is 6 characters)')
+        expect(@user.errors.full_messages).to include('パスワードは6文字以上で入力してください')
       end
 
       it 'passwordは確認用と一致していないと登録できない' do
         @user.password = 'pass12'
         @user.password_confirmation = 'word34'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
+        expect(@user.errors.full_messages).to include("パスワード（確認用）とパスワードの入力が一致しません")
       end
 
       it 'passwordは半角英語だけでは登録できない' do
@@ -65,7 +65,7 @@ RSpec.describe User, type: :model do
         @user.password = password
         @user.password_confirmation = password
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password は半角英数字を含めて入力してください')
+        expect(@user.errors.full_messages).to include('パスワードは半角英数字を含めて入力してください')
       end
 
       it 'passwordは半角数字だけでは登録できない' do
@@ -73,61 +73,61 @@ RSpec.describe User, type: :model do
         @user.password = password
         @user.password_confirmation = password
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password は半角英数字を含めて入力してください')
+        expect(@user.errors.full_messages).to include('パスワードは半角英数字を含めて入力してください')
       end
 
       it 'last_nameが空では登録できない' do
         @user.last_name = nil
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name can't be blank")
+        expect(@user.errors.full_messages).to include("名字を入力してください")
       end
 
       it 'last_nameは全角（漢字・ひらがな・カタカナ）でなければ登録できない' do
         @user.last_name = 'yamada'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Last name は全角（漢字・ひらがな・カタカナ）で入力してください')
+        expect(@user.errors.full_messages).to include('名字は全角（漢字・ひらがな・カタカナ）で入力してください')
       end
 
       it 'first_nameが空では登録できない' do
         @user.first_name = nil
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name can't be blank")
+        expect(@user.errors.full_messages).to include("名前を入力してください")
       end
 
       it 'first_nameは全角（漢字・ひらがな・カタカナ）でなければ登録できない' do
         @user.first_name = 'yamada'
         @user.valid?
-        expect(@user.errors.full_messages).to include('First name は全角（漢字・ひらがな・カタカナ）で入力してください')
+        expect(@user.errors.full_messages).to include('名前は全角（漢字・ひらがな・カタカナ）で入力してください')
       end
 
       it 'last_name_kanaが空では登録できない' do
         @user.last_name_kana = nil
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name kana can't be blank")
+        expect(@user.errors.full_messages).to include("フリガナ（名字）を入力してください")
       end
 
       it 'last_name_kanaは全角カタカナでなければ登録できない' do
         @user.last_name_kana = 'やまだ'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Last name kana は全角カタカナで入力してください')
+        expect(@user.errors.full_messages).to include('フリガナ（名字）は全角カタカナで入力してください')
       end
 
       it 'first_name_kanaが空では登録できない' do
         @user.first_name_kana = nil
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name kana can't be blank")
+        expect(@user.errors.full_messages).to include("フリガナ（名前）を入力してください")
       end
 
       it 'first_name_kanaは全角カタカナでなければ登録できない' do
         @user.first_name_kana = 'たろう'
         @user.valid?
-        expect(@user.errors.full_messages).to include('First name kana は全角カタカナで入力してください')
+        expect(@user.errors.full_messages).to include('フリガナ（名前）は全角カタカナで入力してください')
       end
 
       it 'birthdayが空では登録できない' do
         @user.birthday = nil
         @user.valid?
-        expect(@user.errors.full_messages).to include("Birthday can't be blank")
+        expect(@user.errors.full_messages).to include("生年月日を入力してください")
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,13 +16,13 @@ RSpec.describe User, type: :model do
       it 'nicknameが空では登録できない' do
         @user.nickname = nil
         @user.valid?
-        expect(@user.errors.full_messages).to include("ニックネームを入力してください")
+        expect(@user.errors.full_messages).to include('ニックネームを入力してください')
       end
 
       it 'emailが空では登録できない' do
         @user.email = nil
         @user.valid?
-        expect(@user.errors.full_messages).to include("Eメールを入力してください")
+        expect(@user.errors.full_messages).to include('Eメールを入力してください')
       end
 
       it '重複したemailは登録できない' do
@@ -42,7 +42,7 @@ RSpec.describe User, type: :model do
       it 'passwordが空では登録できない' do
         @user.password = nil
         @user.valid?
-        expect(@user.errors.full_messages).to include("パスワードを入力してください")
+        expect(@user.errors.full_messages).to include('パスワードを入力してください')
       end
 
       it 'passwordは6文字以上でなければ登録できない' do
@@ -57,7 +57,7 @@ RSpec.describe User, type: :model do
         @user.password = 'pass12'
         @user.password_confirmation = 'word34'
         @user.valid?
-        expect(@user.errors.full_messages).to include("パスワード（確認用）とパスワードの入力が一致しません")
+        expect(@user.errors.full_messages).to include('パスワード（確認用）とパスワードの入力が一致しません')
       end
 
       it 'passwordは半角英語だけでは登録できない' do
@@ -79,7 +79,7 @@ RSpec.describe User, type: :model do
       it 'last_nameが空では登録できない' do
         @user.last_name = nil
         @user.valid?
-        expect(@user.errors.full_messages).to include("名字を入力してください")
+        expect(@user.errors.full_messages).to include('名字を入力してください')
       end
 
       it 'last_nameは全角（漢字・ひらがな・カタカナ）でなければ登録できない' do
@@ -91,7 +91,7 @@ RSpec.describe User, type: :model do
       it 'first_nameが空では登録できない' do
         @user.first_name = nil
         @user.valid?
-        expect(@user.errors.full_messages).to include("名前を入力してください")
+        expect(@user.errors.full_messages).to include('名前を入力してください')
       end
 
       it 'first_nameは全角（漢字・ひらがな・カタカナ）でなければ登録できない' do
@@ -103,7 +103,7 @@ RSpec.describe User, type: :model do
       it 'last_name_kanaが空では登録できない' do
         @user.last_name_kana = nil
         @user.valid?
-        expect(@user.errors.full_messages).to include("フリガナ（名字）を入力してください")
+        expect(@user.errors.full_messages).to include('フリガナ（名字）を入力してください')
       end
 
       it 'last_name_kanaは全角カタカナでなければ登録できない' do
@@ -115,7 +115,7 @@ RSpec.describe User, type: :model do
       it 'first_name_kanaが空では登録できない' do
         @user.first_name_kana = nil
         @user.valid?
-        expect(@user.errors.full_messages).to include("フリガナ（名前）を入力してください")
+        expect(@user.errors.full_messages).to include('フリガナ（名前）を入力してください')
       end
 
       it 'first_name_kanaは全角カタカナでなければ登録できない' do
@@ -127,7 +127,7 @@ RSpec.describe User, type: :model do
       it 'birthdayが空では登録できない' do
         @user.birthday = nil
         @user.valid?
-        expect(@user.errors.full_messages).to include("生年月日を入力してください")
+        expect(@user.errors.full_messages).to include('生年月日を入力してください')
       end
     end
   end


### PR DESCRIPTION
# What
アプリを日本語化したことで単体テストが通らなくなったため、テストコードを修正

# Why
アプリの品質保守のため