### PR TITLE
商品画像の複数枚投稿と表示

### DIFF
--- a/app/assets/stylesheets/items/new.css
+++ b/app/assets/stylesheets/items/new.css
@@ -89,6 +89,20 @@
   margin-bottom: 15px;
 }
 
+.preview-box {
+  display: flex;
+}
+
+.preview-hidden {
+  display: none;
+}
+
+.preview-image {
+  width: 25%;
+  height: auto;
+  margin-right: 5px;
+}
+
 /* /出品画像 */
 
 /* 商品名と商品説明 */

--- a/app/assets/stylesheets/items/new.css
+++ b/app/assets/stylesheets/items/new.css
@@ -91,6 +91,7 @@
 
 .preview-box {
   display: flex;
+  flex-wrap: wrap;
 }
 
 .preview-hidden {
@@ -100,7 +101,8 @@
 .preview-image {
   width: 25%;
   height: auto;
-  margin-right: 5px;
+  margin-right: 10px;
+  margin-top: 10px;
 }
 
 /* /出品画像 */

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -49,8 +49,7 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:image, :name, :explain, :price, :category_id, :item_status_id, :shipping_fee_id,
-                                 :prefecture_id, :delivery_id).merge(user_id: current_user.id)
+    params.require(:item).permit(:name, :explain, :price, :category_id, :item_status_id, :shipping_fee_id, :prefecture_id, :delivery_id, images: []).merge(user_id: current_user.id)
   end
 
   def find_item

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -49,7 +49,8 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:name, :explain, :price, :category_id, :item_status_id, :shipping_fee_id, :prefecture_id, :delivery_id, images: []).merge(user_id: current_user.id)
+    params.require(:item).permit(:name, :explain, :price, :category_id, :item_status_id, :shipping_fee_id, :prefecture_id,
+                                 :delivery_id, images: []).merge(user_id: current_user.id)
   end
 
   def find_item

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -11,6 +11,7 @@ require("channels")
 require("../calc")
 require("../card")
 require("../search")
+require("../preview")
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)

--- a/app/javascript/preview.js
+++ b/app/javascript/preview.js
@@ -1,0 +1,20 @@
+const preview = () => {
+  const previewBox = document.getElementById("preview-box");
+  document.getElementById("item-image").addEventListener('change', (e) => {
+    // 画像のデータを取得
+    const file = e.target.files[0]
+    // 画像のデータからURLを生成
+    const imageUrl = window.URL.createObjectURL(file);
+
+    const previewImage = document.createElement('img');
+    previewImage.setAttribute('src', imageUrl);
+
+    // プレビュー画像の見た目を整える
+    previewBox.classList.remove('preview-hidden');
+    previewImage.classList.add('preview-image');
+
+    previewBox.appendChild(previewImage);
+  });
+}
+
+window.addEventListener('load', preview);

--- a/app/javascript/preview.js
+++ b/app/javascript/preview.js
@@ -1,19 +1,47 @@
 const preview = () => {
   const previewBox = document.getElementById("preview-box");
+  const uploadBox = document.getElementById("upload-box");
+
+  const createImageHTML = (imageUrl) => {
+
+    // プレビュー画像用のHTML要素を生成
+    const previewImage = document.createElement('img');
+    previewImage.setAttribute('src', imageUrl);
+    previewImage.setAttribute('class', 'image-element');
+    let imageElementNum = document.querySelectorAll('.image-element').length;
+
+    // プレビュー画像の見た目を整える
+    previewBox.classList.remove('preview-hidden');
+    previewImage.classList.add('preview-image');
+
+    // プレビュー画像を表示させる
+    previewBox.appendChild(previewImage);
+
+    // ２つ目以降のファイル選択ボタンを生成
+    const inputHTML = document.createElement('input');
+    inputHTML.setAttribute('id', `item_image_${imageElementNum}`);
+    inputHTML.setAttribute('name', 'item[images][]');
+    inputHTML.setAttribute('type', 'file');
+
+    // ファイル選択ボタンを表示させる
+    uploadBox.appendChild(inputHTML);
+
+    // ２枚目以降のファイル選択とプレビュー表示も可能にする
+    inputHTML.addEventListener('change', (e) => {
+      const file = e.target.files[0];
+      const imageUrl = window.URL.createObjectURL(file);
+      createImageHTML(imageUrl);
+    });
+  }
+
   document.getElementById("item-image").addEventListener('change', (e) => {
     // 画像のデータを取得
     const file = e.target.files[0]
     // 画像のデータからURLを生成
     const imageUrl = window.URL.createObjectURL(file);
 
-    const previewImage = document.createElement('img');
-    previewImage.setAttribute('src', imageUrl);
-
-    // プレビュー画像の見た目を整える
-    previewBox.classList.remove('preview-hidden');
-    previewImage.classList.add('preview-image');
-
-    previewBox.appendChild(previewImage);
+    // 画像データを突っ込んで上で定義した関数を呼び出す
+    createImageHTML(imageUrl);
   });
 }
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,8 +2,8 @@ class Item < ApplicationRecord
   # モデルとのアソシエーション
   belongs_to :user
   has_one :order
-  # 画像を１枚添付できる
-  has_one_attached :image
+  # 画像を複数枚添付できる
+  has_many_attached :images
 
   # ActiveHashクラスとのアソシエーション定義のためにmoduleを取り込む
   extend ActiveHash::Associations::ActiveRecordExtensions
@@ -14,7 +14,7 @@ class Item < ApplicationRecord
   belongs_to :delivery
 
   with_options presence: true do
-    validates :image
+    validates :images
     validates :name
     validates :explain
     validates :price, format: { with: /\A[0-9]+\z/, message: 'は半角数字で入力してください' },

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -17,7 +17,7 @@ app/assets/stylesheets/items/new.css %>
         出品画像
         <span class="indispensable">必須</span>
       </div>
-      <div class="click-upload">
+      <div class="click-upload" id="upload-box">
         <p>
           クリックしてファイルをアップロード
         </p>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -21,7 +21,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :image, id:"item-image" %>
+        <%= f.file_field :images, name: 'item[images][]', id:"item-image" %>
       </div>
     </div>
     <%# /出品画像 %>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -25,6 +25,11 @@ app/assets/stylesheets/items/new.css %>
       </div>
     </div>
     <%# /出品画像 %>
+    <%# 出品画像のプレビュー %>
+    <div class="preview-box preview-hidden" id="preview-box">
+      <%# この中にpreview.jsで作成するプレビュー画像を挿入 %>
+    </div>
+    <%# 出品画像のプレビュー %>
     <%# 商品名と商品説明 %>
     <div class="new-items">
       <div class="weight-bold-text">
@@ -156,4 +161,8 @@ app/assets/stylesheets/items/new.css %>
       ©︎Furima,Inc.
     </p>
   </footer>
+</div> class="inc">
+©︎Furima,Inc.
+</p>
+</footer>
 </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,7 +130,7 @@
       <li class='list'>
         <%= link_to item_path(item) do %>
         <div class='item-img-content'>
-          <%= image_tag item.image, class: "item-img" %>
+          <%= image_tag item.images[0], class: "item-img" %>
 
           <%# 売り切れ商品はsold outの表示をする %>
           <% if item.order.present? %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -20,7 +20,7 @@
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :image, id:"item-image" %>
+        <%= f.file_field :images, name: 'item[images][]', id:"item-image" %>
       </div>
     </div>
     <%# /出品画像 %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -16,7 +16,7 @@
         出品画像
         <span class="indispensable">必須</span>
       </div>
-      <div class="click-upload">
+      <div class="click-upload" id="upload-box">
         <p>
           クリックしてファイルをアップロード
         </p>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -24,6 +24,11 @@
       </div>
     </div>
     <%# /出品画像 %>
+    <%# 出品画像のプレビュー %>
+    <div class="preview-box preview-hidden" id="preview-box">
+      <%# この中にpreview.jsで作成するプレビュー画像を挿入 %>
+    </div>
+    <%# 出品画像のプレビュー %>
     <%# 商品名と商品説明 %>
     <div class="new-items">
       <div class="weight-bold-text">

--- a/app/views/items/search.html.erb
+++ b/app/views/items/search.html.erb
@@ -29,7 +29,7 @@
       <li class='list'>
         <%= link_to item_path(item) do %>
         <div class='item-img-content'>
-          <%= image_tag item.image, class: "item-img" %>
+          <%= image_tag item.images[0], class: "item-img" %>
 
           <%# 売り切れ商品はsold outの表示をする %>
           <% if item.order.present? %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -7,7 +7,9 @@
       <%= @item.name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag @item.image ,class:"item-box-img" %>
+      <% @item.images.each do |image| %>
+      <%= image_tag image, class:"item-box-img" %>
+      <% end %>
       <%# 売り切れ商品はsold outの表示をする %>
       <% if @item.order.present? %>
       <div class="sold-out">

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -7,7 +7,7 @@
     </h1>
     <%# 購入内容の表示 %>
     <div class='buy-item-info'>
-      <%= image_tag @item.image, class: 'buy-item-img' %>
+      <%= image_tag @item.images[0], class: 'buy-item-img' %>
       <div class='buy-item-right-content'>
         <h2 class='buy-item-text'>
           <%= @item.name %>


### PR DESCRIPTION
# What
商品の出品時に複数の画像を添付できるようにした。
出品時にプレビュー画像が見れるようにした。
サイトの商品画像の表示に関わるコードを修正した。

# Why
商品画像を複数登録できるようにしてユーザーの利便性を向上させるため。